### PR TITLE
Add German translation and translate "Last modified" and "Created"

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,83 @@
+[menu_title]
+other = "Hauptmenü"
+
+[menu_home]
+other = "Home"
+
+[menu_mobile]
+other = "Menü"
+
+[pager_next]
+other = "Weiter"
+
+[pager_prev]
+other = "Zurück"
+
+[taxo_tags]
+other = "Tags"
+
+[search_placeholder]
+other = "Suche"
+
+[search_title]
+other = "Suchbegriffe hier eingeben."
+
+[string_at]
+other = "auf"
+
+[string_by]
+other = "von"
+
+[string_follow]
+other = "folgen"
+
+[string_in]
+other = "in"
+
+[string_on]
+other = "auf"
+
+[string_recent_content]
+other = "Aktuelle Inhalte"
+
+[contact_js]
+other = "Javascript muss aktiviert sein um dieses Kontaktformular zu nutzen."
+
+[contact_submitted]
+other = "Die Nachricht wurde versendet."
+
+[contact_error]
+other = "Beim Senden der Nachricht ist ein Fehler aufgetreten."
+
+[contact_name]
+other = "Name"
+
+[contact_name_placeholder]
+other = "Dein Name"
+
+[contact_mail]
+other = "E-Mail Adresse"
+
+[contact_mail_placeholder]
+other = "Deine E-Mail Adresse"
+
+[contact_subject]
+other = "Betreff"
+
+[contact_subject_placeholder]
+other = "Eine kurze Beschreibung"
+
+[contact_message]
+other = "Nachricht"
+
+[contact_message_placeholder]
+other = "Hier den Nachrichtentext eingeben…"
+
+[contact_submit]
+other = "Nachricht senden"
+
+[contact_honypot]
+other = "Überspringen, wenn du ein Mensch bist"
+
+[lang_select_title]
+other = "Sprachauswahl"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -16,6 +16,12 @@ other = "Zurück"
 [taxo_tags]
 other = "Tags"
 
+[last_mod]
+other = "Zuletzt geändert:"
+
+[created]
+other = "Erstellt:"
+
 [search_placeholder]
 other = "Suche"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -16,6 +16,12 @@ other = "Prev"
 [taxo_tags]
 other = "Tags"
 
+[last_mod]
+other = "Last modified:"
+
+[created]
+other = "Created:"
+
 [search_placeholder]
 other = "Search"
 

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -16,6 +16,12 @@ other = "Précédent"
 [taxo_tags]
 other = "Tags"
 
+[last_mod]
+other = "Dernière modification:"
+
+[created]
+other = "Établi:"
+
 [search_placeholder]
 other = "Rechercher"
 

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -16,6 +16,12 @@ other = "Anterior"
 [taxo_tags]
 other = "Tags"
 
+[last_mod]
+other = "Última modificação:"
+
+[created]
+other = "Criado:"
+
 [search_placeholder]
 other = "Procurar"
 

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -16,6 +16,12 @@ other = "Föregående"
 [taxo_tags]
 other = "Taggar"
 
+[last_mod]
+other = "Senast ändrad:"
+
+[created]
+other = "Skapad:"
+
 [search_placeholder]
 other = "Sök"
 

--- a/layouts/partials/dates.html
+++ b/layouts/partials/dates.html
@@ -1,4 +1,4 @@
 <p class="content-dates">
-Last modified: {{ .Lastmod.Format ($.Param "dateformat" | default "2 January, 2006") }}<br>
-Created: {{ .Date.Format ($.Param "dateformat" | default "2 January, 2006") }}
+{{ i18n "last_mod" }} {{ .Lastmod.Format ($.Param "dateformat" | default "2 January, 2006") }}<br>
+{{ i18n "created" }} {{ .Date.Format ($.Param "dateformat" | default "2 January, 2006") }}
 </p>


### PR DESCRIPTION
Here's a small pull request with two translation changes:
1. Adds a German translation
2. Adds translations for "Last modified" and "Created", which are currently hardcoded in English.

Please note, that for the second change, the translations for French, Portuguese and Swedish were done with Google Translator. Therefore they might not be 100% correct.