### PR TITLE
add aria-current to active class in menus and sidebar

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -4,12 +4,12 @@
 <nav class="main-menu layout__navigation">
 <h2 class="visually-hidden">{{ i18n "menu_title" }}</h2>
 <ul class="navbar">
-{{ with .Site.Home }}<li><a class="{{ if eq $currentID .File.UniqueID }}active{{ end }}" href="{{ .RelPermalink }}">{{ i18n "menu_home" }}</a></li>{{ end }}
+{{ with .Site.Home }}<li><a class="{{ if eq $currentID .File.UniqueID }}active" aria-current="page{{ end }}" href="{{ .RelPermalink }}">{{ i18n "menu_home" }}</a></li>{{ end }}
 {{ range where .Site.RegularPages "Section" "" -}}
-<li><a class="{{ if eq $currentID .File.UniqueID }}active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+<li><a class="{{ if eq $currentID .File.UniqueID }}active" aria-current="page{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
 {{ end -}}
 {{ range .Site.Sections -}}
-<li><a class="{{ if eq $currentSection .Section }}active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+<li><a class="{{ if eq $currentSection .Section }}active" aria-current="page{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
 {{ end -}}
 </ul>
 </nav>

--- a/layouts/partials/mobilemenu.html
+++ b/layouts/partials/mobilemenu.html
@@ -12,12 +12,12 @@
     <nav class="mobile-nav__main-menu">
     <h2 class="visually-hidden">{{ i18n "menu_title" }}</h2>
     <ul class="mobile-nav__navbar">
-    {{ with .Site.Home }}<li><a class="{{ if eq $currentID .File.UniqueID }}active{{ end }}" href="{{ .RelPermalink }}">{{ i18n "menu_home" }}</a></li>{{ end }}
+    {{ with .Site.Home }}<li><a class="{{ if eq $currentID .File.UniqueID }}active" aria-current="page{{ end }}" href="{{ .RelPermalink }}">{{ i18n "menu_home" }}</a></li>{{ end }}
     {{ range where .Site.RegularPages "Section" "" -}}
-    <li><a class="{{ if eq $currentID .File.UniqueID }}active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    <li><a class="{{ if eq $currentID .File.UniqueID }}active" aria-current="page{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
     {{ end -}}
     {{ range .Site.Sections -}}
-    <li><a class="{{ if eq $currentSection .Section }}active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    <li><a class="{{ if eq $currentSection .Section }}active" aria-current="page{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
     {{ end -}}
     </ul>
     </nav>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -4,10 +4,10 @@
 <aside class="sidebar layout__second-sidebar">
 {{ range .Site.Sections -}}
 <section>
-<h4 class="menu"><a class="{{ if eq $currentSection .Section }}active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></h4>
+<h4 class="menu"><a class="{{ if eq $currentSection .Section }}active" aria-current="page{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></h4>
 <ul class="menu">
 {{ range .Pages -}}
-<li><a class="{{ if eq $currentID .File.UniqueID }}active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+<li><a class="{{ if eq $currentID .File.UniqueID }}active" aria-current="page{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
 {{ end -}}
 </ul>
 </section>


### PR DESCRIPTION
The menus indicate the active page/section with a CSS class which makes them visually different from the others. However, screen reading software (IE NVDA on Windows or VoiceOver on Mac/iOS) don't react to this, so they just read the link like any other. I applied the aria-current attribute to all instances where the active class is applied which makes screen readers say "current page" on them. Since this message is provided by the screen reader itself, it doesn't need to be localised as it'll match the language of someone's OS/Software.