### PR TITLE
Added call to GA & fixed tag lists

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,6 +10,7 @@
 {{ partial "meta_json_ld.html" . }}
 {{ partial "scripts.html" . }}
 {{ partialCached "matomo.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 </head>
 
 <body class="{{ if .IsPage }}single-page{{ else }}list-page{{ end }}{{ if .IsHome }} front{{ end }}">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,6 @@
 {{ partial "meta_json_ld.html" . }}
 {{ partial "scripts.html" . }}
 {{ partialCached "matomo.html" . }}
-{{ template "_internal/google_analytics.html" . }}
 </head>
 
 <body class="{{ if .IsPage }}single-page{{ else }}list-page{{ end }}{{ if .IsHome }} front{{ end }}">

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -2,7 +2,7 @@
 {{ i18n "taxo_tags" }}:
 <ul>
 {{ range .Params.tags -}}
-<li><a href="{{ "/tags/" | relURL }}{{ . | urlize }}">{{ . }}</a></li>
+<li><a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a></li>
 {{ end -}}
 </ul>
 </div>


### PR DESCRIPTION
Hi!

Sorry for mixing two commits.
The first one adds generation of GA in the <head>. The other one fixes the tags list generated in content's page, so now it takes the language into account as well.

Thanks
Piotr