### PR TITLE
Remove extra space

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -15,7 +15,7 @@
 {{ if and (.Get "width") (.Get "height") -}}
     {{ $width = (int (.Get "width")) -}}
     {{ $height = (int (.Get "height")) -}}
-{{ else if (.Get "width")  -}}
+{{ else if (.Get "width") -}}
   {{ $width = (int (.Get "width")) -}}
   {{ if and ($realwidth) (lt ($width) ($realwidth)) -}}
     {{ $height = (mul ($realheight) (div (add ($width) 0.0) ($realwidth))) -}}


### PR DESCRIPTION
Encountered an issue https://github.com/frjo/hugo-theme-zen/issues/16.
Per forum, this may help an error. https://discourse.gohugo.io/t/error-with-template-illegal-number-syntax/21148/4

In addition to the above, another thread regards to the same error message.
https://github.com/golang/go/issues/30948