### PR TITLE
Update minimum Hugo version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ https://themes.gohugo.io/theme/hugo-theme-zen/
 
 ## Minimum Hugo version
 
-Hugo Extended version 0.57.0 or higher is required.
+Hugo Extended version 0.67.1 or higher is required.
 
 
 ## Installation


### PR DESCRIPTION
I'm trying to make this wonderful theme as my base for my site revamp and I was using Hugo v0.64.1. I am not aware of the current Hugo version and its features so I was surprised with the following error when I'm running the example site `hugo server --themesDir ../..` on the `exampleSite` folder:

```
Building sites … ERROR 2020/07/31 20:30:10 render of "page" failed:
"/Users/apraditya/labs/hugo/devmuslimid/themes/zen/layouts/_default/baseof.html:2:65":
execute of template failed: template: _default/single.html:2:65: executing
"_default/single.html" at <.Site.Language.LanguageDirection>: can't evaluate field
LanguageDirection in type *langs.Language
```

Looks fine on the template: `_default/single.html:2:65`. After some time, I found out that my Hugo version was older than this theme required. So I thought I'd update this in the README.