### PR TITLE
Add support for Google Analytics with Content security policy headers

### DIFF
--- a/assets/js/tracking.js
+++ b/assets/js/tracking.js
@@ -11,3 +11,9 @@ _paq.push(['setTrackerUrl', matomoTrackingApiUrl]);
 _paq.push(['setSiteId', idSite]);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
+
+var googleAnalytics = {{ .Site.GoogleAnalytics }};
+
+var _gaq = window._gaq || [];
+_gaq.push(['_setAccount', googleAnalytics]);
+_gaq.push(['_trackPageView']);

--- a/layouts/partials/matomo.html
+++ b/layouts/partials/matomo.html
@@ -3,3 +3,9 @@
 <script src="{{ $script.RelPermalink }}"></script>
 <script defer src="https://{{ .Site.Params.piwikTrackerUrl }}/matomo.js"></script>
 {{ end -}}
+
+{{ if .Site.GoogleAnalytics -}}
+{{ $script := resources.Get "js/tracking.js" | resources.ExecuteAsTemplate "js/tracking.js" . | minify | fingerprint -}}
+<script src="{{ $script.RelPermalink }}"></script>
+<script defer src="https://ssl.google-analytics.com/ga.js"></script>
+{{ end -}}


### PR DESCRIPTION
Following your blog post on [Content security policy headers](https://xdeb.org/post/2020/01/14/content-security-policy-headers-when-using-matomo-or-google-analytics/#google-analytics) in #24, here's my approach.

I stick with `matomo` partial and not adding new `google-analytics` partial because I want to avoid adding another line / handling which partial to use in `layouts/_default/baseof.html`.

If you agree with this, then I'd suggest to rename `matomo` partial with `tracking` to make more sense. What do you think?