### PR TITLE
Don't show date of post when it is not set

### DIFF
--- a/layouts/micro/single.html
+++ b/layouts/micro/single.html
@@ -4,8 +4,7 @@
 <header>
 <h1 class="hidden">{{ .Title }}</h1>
 <p>
-{{ with $.Param "author" }}<span class="author">{{ . }}</span> – {{ end -}}
-<time class="created-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format ($.Param "dateformat" | default "2 January, 2006") }}</time>
+{{ partial "author-date" . }}
 </p>
 </header>
 <div class="content">

--- a/layouts/micro/summary.html
+++ b/layouts/micro/summary.html
@@ -2,8 +2,7 @@
 <header>
 <h2 class="hidden">{{ .Title }}</h2>
 <p><a href="{{ .RelPermalink }}">
-{{ with $.Param "author" }}<span class="author">{{ . }}</span> – {{ end -}}
-<time class="created-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format ($.Param "dateformat" | default "2 January, 2006") }}</time>
+{{ partial "author-date" . }}
 </a></p>
 </header>
 <div class="content">

--- a/layouts/partials/author-date.html
+++ b/layouts/partials/author-date.html
@@ -1,3 +1,3 @@
-{{ with .Param "author" }}<span class="author" itemprop="author">{{ . }}</span>{{ end -}}
-{{ if and .Date (.Param "author") }} - {{ end -}}
+{{ with $.Param "author" }}<span class="author" itemprop="author">{{ . }}</span>{{ end -}}
+{{ if and .Date ($.Param "author") }} - {{ end -}}
 {{ with .Date }}<time class="created-date" datetime="{{ .Format "2006-01-02T15:04:05Z07:00" }}">{{ .Format ($.Param "dateformat" | default "2 January, 2006") }}</time>{{ end }}

--- a/layouts/partials/author-date.html
+++ b/layouts/partials/author-date.html
@@ -1,2 +1,3 @@
-{{ with $.Param "author" }}<span class="author" itemprop="author">{{ . }}</span> – {{ end -}}
-<time class="created-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format ($.Param "dateformat" | default "2 January, 2006") }}</time>
+{{ with .Param "author" }}<span class="author" itemprop="author">{{ . }}</span>{{ end -}}
+{{ if and .Date (.Param "author") }} - {{ end -}}
+{{ with .Date }}<time class="created-date" datetime="{{ .Format "2006-01-02T15:04:05Z07:00" }}">{{ .Format ($.Param "dateformat" | default "2 January, 2006") }}</time>{{ end }}

--- a/layouts/partials/author-date.html
+++ b/layouts/partials/author-date.html
@@ -1,0 +1,2 @@
+{{ with $.Param "author" }}<span class="author" itemprop="author">{{ . }}</span> – {{ end -}}
+<time class="created-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format ($.Param "dateformat" | default "2 January, 2006") }}</time>

--- a/layouts/partials/submitted.html
+++ b/layouts/partials/submitted.html
@@ -1,4 +1,3 @@
 <div class="submitted">
-{{ with $.Param "author" }}<span class="author" itemprop="author">{{ . }}</span> – {{ end -}}
-<time class="created-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format ($.Param "dateformat" | default "2 January, 2006") }}</time>
+{{ partial "author-date" . }}
 </div>


### PR DESCRIPTION
This moves duplicate code to a common partial and hides the date information when the date of a post is not set.