### PR TITLE
Add schema.org BreadcrumbList to JSON+LD

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,13 @@ languageCode: "en-GB"       # Set your language code (only needed for none multi
 
 params:
   alpine:                   # Add AlpineJS, default false.
+  blogSections:             # Sections whose <schema.org> `JSON+LD` in the page `<head>`
+    - blog                  # will be `@type: BlogPosting`.
+    - post                  # Defaults to a list including only 'post' and 'blog'.
+  breadcrumbSections:       # Sections in which pages will have a `BreadcrumbListing`
+    - section2              # in the <schema.org> `JSON+LD` in the page's `<head>`.
+    - section3              # This theme requires Hugo `v0.109.0` or higher to
+                            # generate the `BreadcrumbListing`.
   cookieConsent: true       # Show cookie consent form, default false.
   contact: "info@example.org"
   copyright: "This site is licensed under a 

--- a/layouts/partials/meta_breadcrumb_json_ld.html
+++ b/layouts/partials/meta_breadcrumb_json_ld.html
@@ -25,4 +25,5 @@
 {{- $breadcrumbScratch.SetInMap "breadcrumb" "@context" "https://schema.org" -}}
 {{- $breadcrumbScratch.SetInMap "breadcrumb" "@type" "BreadcrumbList" -}}
 {{- $breadcrumbScratch.SetInMap "breadcrumb" "itemListElement" ($crumbScratch.Get "itemListElement") -}}
-{{- return ($breadcrumbScratch.Get "breadcrumb") | jsonify -}}
+{{- $jsonifiedBreadcrumb := $breadcrumbScratch.Get "breadcrumb" | jsonify (dict "indent" "  " "prefix" "    ") -}}
+{{- return $jsonifiedBreadcrumb -}}

--- a/layouts/partials/meta_breadcrumb_json_ld.html
+++ b/layouts/partials/meta_breadcrumb_json_ld.html
@@ -1,0 +1,28 @@
+{{- $breadcrumbScratch := newScratch -}}
+{{- $crumbScratch := newScratch -}}
+{{- $crumbScratch.Set "itemListElement" (slice) -}}
+{{- $breadPos := 0 -}}
+{{- range .Ancestors.Reverse -}}
+  {{- $breadPos = (add $breadPos 1) -}}
+  {{- $crumbScratch.Add "itemListElement" (dict
+    "@type" "ListItem"
+    "position" $breadPos
+    "item" (dict
+      "@id" .Permalink
+      "name" .LinkTitle
+    )
+  ) -}}
+{{- end -}}
+{{- $breadPos = (add $breadPos 1) -}}
+{{- $crumbScratch.Add "itemListElement" (dict
+  "@type" "ListItem"
+  "position" $breadPos
+  "item" (dict
+    "@id" .Permalink
+    "name" .LinkTitle
+  )
+) -}}
+{{- $breadcrumbScratch.SetInMap "breadcrumb" "@context" "https://schema.org" -}}
+{{- $breadcrumbScratch.SetInMap "breadcrumb" "@type" "BreadcrumbList" -}}
+{{- $breadcrumbScratch.SetInMap "breadcrumb" "itemListElement" ($crumbScratch.Get "itemListElement") -}}
+{{- return ($breadcrumbScratch.Get "breadcrumb") | jsonify -}}

--- a/layouts/partials/meta_json_ld.html
+++ b/layouts/partials/meta_json_ld.html
@@ -3,7 +3,7 @@
     "@context": "https://schema.org",
     {{ if .IsPage -}}
     "@type": {{ if or (eq .Section "blog") (eq .Section "post") }}"BlogPosting"{{ else }}"WebPage"{{ end }},
-    {{ if not (or (eq .Section "blog") (eq .Section "post")) }}"breadcrumb": {{ partial "meta_breadcrumb_json_ld.html" . }}{{ end }},
+    {{ if not (or (eq .Section "blog") (eq .Section "post")) }}"breadcrumb": {{ partial "meta_breadcrumb_json_ld.html" . }},{{ end }}
     "headline": {{ .Title }},
     "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" }},
     "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }},

--- a/layouts/partials/meta_json_ld.html
+++ b/layouts/partials/meta_json_ld.html
@@ -3,6 +3,7 @@
     "@context": "https://schema.org",
     {{ if .IsPage -}}
     "@type": {{ if or (eq .Section "blog") (eq .Section "post") }}"BlogPosting"{{ else }}"WebPage"{{ end }},
+    {{ if not (or (eq .Section "blog") (eq .Section "post")) }}"breadcrumb": {{ partial "meta_breadcrumb_json_ld.html" . }}{{ end }},
     "headline": {{ .Title }},
     "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" }},
     "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }},
@@ -15,6 +16,7 @@
     {{ end -}}
     {{ else -}}
     "@type": "WebPage",
+    "breadcrumb": {{ partial "meta_breadcrumb_json_ld.html" . }},
     "url" : {{ .Permalink }},
     "name": {{ .Title }},
     {{ with $.Param "description" -}}

--- a/layouts/partials/meta_json_ld.html
+++ b/layouts/partials/meta_json_ld.html
@@ -3,7 +3,7 @@
     "@context": "https://schema.org",
     {{ if .IsPage -}}
     "@type": {{ if or (eq .Section "blog") (eq .Section "post") }}"BlogPosting"{{ else }}"WebPage"{{ end }},
-    {{ if not (or (eq .Section "blog") (eq .Section "post")) }}"breadcrumb": {{ partial "meta_breadcrumb_json_ld.html" . }},{{ end }}
+    {{ if not (or (eq .Section "blog") (eq .Section "post")) }}"breadcrumb": {{ safeJS (partial "meta_breadcrumb_json_ld.html" .) }},{{ end }}
     "headline": {{ .Title }},
     "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" }},
     "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }},
@@ -16,7 +16,7 @@
     {{ end -}}
     {{ else -}}
     "@type": "WebPage",
-    "breadcrumb": {{ partial "meta_breadcrumb_json_ld.html" . }},
+    "breadcrumb": {{ safeJS (partial "meta_breadcrumb_json_ld.html" .) }},
     "url" : {{ .Permalink }},
     "name": {{ .Title }},
     {{ with $.Param "description" -}}

--- a/layouts/partials/meta_json_ld.html
+++ b/layouts/partials/meta_json_ld.html
@@ -1,9 +1,17 @@
 <script type="application/ld+json">
+{{- $blogSections := site.Params.blogSections | default (slice "blog" "post") }}
+{{- $breadcrumbSections := site.Params.breadcrumbSections | default (slice) }}
   {
     "@context": "https://schema.org",
     {{ if .IsPage -}}
-    "@type": {{ if or (eq .Section "blog") (eq .Section "post") }}"BlogPosting"{{ else }}"WebPage"{{ end }},
-    {{ if not (or (eq .Section "blog") (eq .Section "post")) }}"breadcrumb": {{ safeJS (partial "meta_breadcrumb_json_ld.html" .) }},{{ end }}
+    "@type": {{ if in $blogSections .Section -}}
+      "BlogPosting",
+      {{- else -}}
+      "WebPage",
+        {{- if in $breadcrumbSections .Section }}
+    "breadcrumb": {{ safeJS (partial "meta_breadcrumb_json_ld.html" .) }},
+        {{- end -}}
+      {{- end }}
     "headline": {{ .Title }},
     "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" }},
     "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }},
@@ -16,7 +24,9 @@
     {{ end -}}
     {{ else -}}
     "@type": "WebPage",
+      {{- if in $breadcrumbSections .Section }}
     "breadcrumb": {{ safeJS (partial "meta_breadcrumb_json_ld.html" .) }},
+      {{- end }}
     "url" : {{ .Permalink }},
     "name": {{ .Title }},
     {{ with $.Param "description" -}}


### PR DESCRIPTION
This implementation depends on .Page.Ancestors, which requires Hugo version v0.109.0.

I expect changes to be requested, hence the 'Draft' PR type.

If v0.109.0 is too high to require, I'll work on a non-`.Ancestors` option for older versions of Hugo.