### PR TITLE
Add demosite to theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -1,6 +1,7 @@
 name = "Zen"
 description = "A solid base for your custom Hugo theme with pipes support for Sass and Javascript."
 homepage = "https://github.com/frjo/hugo-theme-zen"
+demosite = "https://zen-demo.xdeb.org/"
 license = "GPLv2"
 licenselink = "http://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 tags = ["accessible", "multilingual", "responsive", "blog", "search", "math", "podcast"]


### PR DESCRIPTION
So that a direct link to the demo site is generated at https://themes.gohugo.io/themes/hugo-theme-zen/, just like [here](https://themes.gohugo.io/themes/hugo-book/).

I really like the theme and appreciate the JSON feed. Thanks <3